### PR TITLE
Set Docker image labels

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,4 +1,11 @@
 FROM java:8-jre
+LABEL org.label-schema.vendor="Atomist, Inc."\
+	org.label-schema.name="rug-cli"\
+	org.label-schema.description="CLI to build and run rugs"\
+	org.label-schema.url="https://github.com/atomist/rug-cli"\
+	org.label-schema.vcs-url="https://github.com/atomist/rug-cli.git"\
+	org.label-schema.vcs-type="git"\
+	org.label-schema.license="GPLv3"
 
 COPY lib /opt/build/lib/
 COPY @project.build.finalName@.jar /opt/build/


### PR DESCRIPTION
It's good practice to set those labels so images
can be queried for their metadata.