### PR TITLE
Make the error message for `rug describe` better 

### DIFF
--- a/src/main/java/com/atomist/rug/cli/command/AbstractLocalArtifactDescriptorProvider.java
+++ b/src/main/java/com/atomist/rug/cli/command/AbstractLocalArtifactDescriptorProvider.java
@@ -39,7 +39,7 @@ public abstract class AbstractLocalArtifactDescriptorProvider extends AbstractCo
             return new ManifestArtifactDescriptorCreator().create(manifest, projectRoot.toURI());
         }
 
-        throw new CommandException("No manifest.yml or package.json found in .atomist folder",
+        throw new CommandException("No manifest.yml found in .atomist folder. Please add a manifest.yml file and run the command again.",
                 (String) null);
     }
 }

--- a/src/main/java/com/atomist/rug/cli/command/CommandException.java
+++ b/src/main/java/com/atomist/rug/cli/command/CommandException.java
@@ -20,11 +20,11 @@ public class CommandException extends RuntimeException {
 
     private static String getHelpText(String command) {
         if (command == null) {
-            return String.format("\n\nRun the following command for usage help:\n  %s --help.",
+            return String.format("\n\nRun the following command for usage help:\n  %s --help",
                     Constants.COMMAND);
         }
         else {
-            return String.format("\n\nRun the following command for usage help:\n  %s %s --help.",
+            return String.format("\n\nRun the following command for usage help:\n  %s %s --help",
                     Constants.COMMAND, command);
         }
     }

--- a/src/main/java/com/atomist/rug/cli/command/describe/DescribeCommand.java
+++ b/src/main/java/com/atomist/rug/cli/command/describe/DescribeCommand.java
@@ -76,8 +76,16 @@ public class DescribeCommand extends AbstractAnnotationBasedCommand {
         case "archive":
             describeArchive(artifact, source, operationsAndHandlers);
             break;
+        case "":
+            throw new CommandException("Please tell me the TYPE and the NAME of what you would like me to describe.", "describe");
         default:
-            throw new CommandException("No or invalid TYPE provided.", "describe");
+            if (kind.split(":").length == 2) {
+                throw new CommandException("It looks like you're trying to describe an archive. Please try: rug describe archive " + kind, "describe");
+            }
+            if (kind.split(":").length == 3) {
+                throw new CommandException("Please tell me what kind of thing to describe. Try: rug describe [editor|generator|executor] " + kind, "describe");
+            }
+            throw new CommandException("Invalid TYPE provided. Please tell me what you would like to describe: archive, editor, generator, or executor.", "describe");
         }
     }
 

--- a/src/main/java/com/atomist/rug/cli/command/describe/DescribeCommand.java
+++ b/src/main/java/com/atomist/rug/cli/command/describe/DescribeCommand.java
@@ -77,15 +77,15 @@ public class DescribeCommand extends AbstractAnnotationBasedCommand {
             describeArchive(artifact, source, operationsAndHandlers);
             break;
         case "":
-            throw new CommandException("Please tell me the TYPE and the NAME of what you would like me to describe.", "describe");
+            throw new CommandException("Invalid TYPE provided. Please tell me what you would like to describe: archive, editor, generator, executor or reviewer.", "describe");
         default:
             if (kind.split(":").length == 2) {
-                throw new CommandException("It looks like you're trying to describe an archive. Please try: rug describe archive " + kind, "describe");
+                throw new CommandException("It looks like you're trying to describe an archive. Please try:\n  rug describe archive " + kind, "describe");
             }
             if (kind.split(":").length == 3) {
-                throw new CommandException("Please tell me what kind of thing to describe. Try: rug describe [editor|generator|executor] " + kind, "describe");
+                throw new CommandException("Please tell me what kind of thing to describe. Try:\n  rug describe editor|generator|executor|reviewer " + kind, "describe");
             }
-            throw new CommandException("Invalid TYPE provided. Please tell me what you would like to describe: archive, editor, generator, or executor.", "describe");
+            throw new CommandException("Invalid TYPE provided. Please tell me what you would like to describe: archive, editor, generator, executor or reviewer.", "describe");
         }
     }
 

--- a/src/main/java/com/atomist/rug/cli/command/describe/DescribeCommandInfo.java
+++ b/src/main/java/com/atomist/rug/cli/command/describe/DescribeCommandInfo.java
@@ -13,7 +13,7 @@ import com.atomist.rug.resolver.ArtifactDescriptor;
 public class DescribeCommandInfo extends AbstractVersionCommandInfo implements CommandInfo {
 
     private static List<String> commands = Arrays
-            .asList("e  ditor", "generator", "executor", "reviewer", "archive");
+            .asList("editor", "generator", "executor", "reviewer", "archive");
 
     public DescribeCommandInfo() {
         super(DescribeCommand.class, "describe", 2);

--- a/src/test/java/com/atomist/rug/cli/AbstractCommandTest.java
+++ b/src/test/java/com/atomist/rug/cli/AbstractCommandTest.java
@@ -74,7 +74,8 @@ public abstract class AbstractCommandTest {
         File config = new File("../cli.yml");
 
         if (!config.exists()) {
-            throw new RuntimeException("Config file missing at ../cli.yml\nLook, if you're running tests locally, try setting your working directory to src/test/resources/common-editors");
+            throw new RuntimeException(
+                    "Config file missing at ../cli.yml\nLook, if you're running tests locally, try setting your working directory to src/test/resources/common-editors");
         }
 
         List<String> commandLine = new ArrayList<>(Arrays.asList(tokens));
@@ -103,12 +104,10 @@ public abstract class AbstractCommandTest {
             String sysout = systemOutRule.getLogWithNormalizedLineSeparator();
             String stderr = systemErrRule.getLogWithNormalizedLineSeparator();
             if (!sysout.contains(requiredContent) && !stderr.contains(requiredContent)) {
-                System.out.println("Received on sysout: <" + sysout + ">\n and on stderr: <" + stderr + ">\nneither of which contain: <" + requiredContent + ">" );
+                System.out.println("Received on sysout: <\n" + sysout + "\n> and on stderr: <\n"
+                        + stderr + "\n> neither of which contain: <\n" + requiredContent + "\n>");
             }
-            assertTrue(sysout.contains(requiredContent)
-                    || stderr.contains(requiredContent));
+            assertTrue(sysout.contains(requiredContent) || stderr.contains(requiredContent));
         }
-
     }
-
 }

--- a/src/test/java/com/atomist/rug/cli/AbstractCommandTest.java
+++ b/src/test/java/com/atomist/rug/cli/AbstractCommandTest.java
@@ -73,6 +73,10 @@ public abstract class AbstractCommandTest {
     protected String[] commandLine(boolean includeConf, String... tokens) {
         File config = new File("../cli.yml");
 
+        if (!config.exists()) {
+            throw new RuntimeException("Config file missing at ../cli.yml\nLook, if you're running tests locally, try setting your working directory to src/test/resources/common-editors");
+        }
+
         List<String> commandLine = new ArrayList<>(Arrays.asList(tokens));
         if (includeConf) {
             commandLine.add("-q");
@@ -95,8 +99,14 @@ public abstract class AbstractCommandTest {
 
         @Override
         public void checkAssertion() throws Exception {
-            assertTrue(systemOutRule.getLogWithNormalizedLineSeparator().contains(requiredContent)
-                    || systemErrRule.getLogWithNormalizedLineSeparator().contains(requiredContent));
+
+            String sysout = systemOutRule.getLogWithNormalizedLineSeparator();
+            String stderr = systemErrRule.getLogWithNormalizedLineSeparator();
+            if (!sysout.contains(requiredContent) && !stderr.contains(requiredContent)) {
+                System.out.println("Received on sysout: <" + sysout + ">\n and on stderr: <" + stderr + ">\nneither of which contain: <" + requiredContent + ">" );
+            }
+            assertTrue(sysout.contains(requiredContent)
+                    || stderr.contains(requiredContent));
         }
 
     }

--- a/src/test/java/com/atomist/rug/cli/RunnerTest.java
+++ b/src/test/java/com/atomist/rug/cli/RunnerTest.java
@@ -41,7 +41,7 @@ public class RunnerTest extends AbstractCommandTest {
 
     @Test
     public void testInvalidOption() throws Exception {
-        assertFailure("Run the following command for usage help:\n" + "  rug --help.", "-p");
+        assertFailure("Run the following command for usage help:\n" + "  rug --help", "-p");
     }
 
     @Test

--- a/src/test/java/com/atomist/rug/cli/command/describe/DescribeCommandIntegrationTest.java
+++ b/src/test/java/com/atomist/rug/cli/command/describe/DescribeCommandIntegrationTest.java
@@ -89,25 +89,32 @@ public class DescribeCommandIntegrationTest extends AbstractCommandTest {
 
     @Test
     public void testUnSuccessfulDescribe() throws Exception {
-        assertFailure("Please tell me the TYPE and the NAME of what you would like me to describe.\n\n"
-                + "Run the following command for usage help:\n" + "  rug describe --help.",
+        assertFailure(
+                "Invalid TYPE provided. Please tell me what you would like to describe: archive, editor, generator, executor or reviewer.\n" + 
+                "\n" + 
+                "Run the following command for usage help:\n" + 
+                "  rug describe --help",
                 "describe", "-l");
     }
 
     @Test
     public void testUnSuccessfulDescribeArchiveForgotType() throws Exception {
-        String archiveIWantedToDescribe =  "atomist-rugs:spring-boot-rest-service";
-        assertFailure("Please try: rug describe archive " + archiveIWantedToDescribe + "\n\n"
-                        + "Run the following command for usage help:\n" + "  rug describe --help.",
+        String archiveIWantedToDescribe = "atomist-rugs:spring-boot-rest-service";
+        assertFailure(
+                "It looks like you're trying to describe an archive. Please try:\n"
+                        + "  rug describe archive " + archiveIWantedToDescribe + "\n" + "\n"
+                        + "Run the following command for usage help:\n" + "  rug describe --help",
                 "describe", archiveIWantedToDescribe);
     }
-
 
     @Test
     public void testUnSuccessfulDescribeEditorForgotType() throws Exception {
         String editorIWantedToDescribe = "atomist-rugs:spring-boot-rest-service:NewBootyThing";
-        assertFailure(" Please tell me what kind of thing to describe. Try: rug describe [editor|generator|executor] " + editorIWantedToDescribe + "\n\n"
-                        + "Run the following command for usage help:\n" + "  rug describe --help.",
+        assertFailure(
+                "Please tell me what kind of thing to describe. Try:\n"
+                        + "  rug describe editor|generator|executor|reviewer "
+                        + editorIWantedToDescribe + "\n" + "\n"
+                        + "Run the following command for usage help:\n" + "  rug describe --help",
                 "describe", editorIWantedToDescribe);
     }
 
@@ -115,7 +122,7 @@ public class DescribeCommandIntegrationTest extends AbstractCommandTest {
     public void testUnSuccessfulDescribeOffline() throws Exception {
         assertFailure(
                 "No valid ARTIFACT provided, no default artifact defined and not in local mode.\n\n"
-                        + "Run the following command for usage help:\n" + "  rug describe --help.",
+                        + "Run the following command for usage help:\n" + "  rug describe --help",
                 "-oX", "describe");
     }
 

--- a/src/test/java/com/atomist/rug/cli/command/describe/DescribeCommandIntegrationTest.java
+++ b/src/test/java/com/atomist/rug/cli/command/describe/DescribeCommandIntegrationTest.java
@@ -89,9 +89,26 @@ public class DescribeCommandIntegrationTest extends AbstractCommandTest {
 
     @Test
     public void testUnSuccessfulDescribe() throws Exception {
-        assertFailure("No or invalid TYPE provided.\n\n"
-                + "Run the following command for usage help:\n" + "  rug describe --help.", "-X",
+        assertFailure("Please tell me the TYPE and the NAME of what you would like me to describe.\n\n"
+                + "Run the following command for usage help:\n" + "  rug describe --help.",
                 "describe", "-l");
+    }
+
+    @Test
+    public void testUnSuccessfulDescribeArchiveForgotType() throws Exception {
+        String archiveIWantedToDescribe =  "atomist-rugs:spring-boot-rest-service";
+        assertFailure("Please try: rug describe archive " + archiveIWantedToDescribe + "\n\n"
+                        + "Run the following command for usage help:\n" + "  rug describe --help.",
+                "describe", archiveIWantedToDescribe);
+    }
+
+
+    @Test
+    public void testUnSuccessfulDescribeEditorForgotType() throws Exception {
+        String editorIWantedToDescribe = "atomist-rugs:spring-boot-rest-service:NewBootyThing";
+        assertFailure(" Please tell me what kind of thing to describe. Try: rug describe [editor|generator|executor] " + editorIWantedToDescribe + "\n\n"
+                        + "Run the following command for usage help:\n" + "  rug describe --help.",
+                "describe", editorIWantedToDescribe);
     }
 
     @Test


### PR DESCRIPTION
when I forget to provide a TYPE.

This took me a while to figure out, so I want to make it easier for others.
This way, it makes a guess at what I'm trying to do, and tells me what the valid types are.