### PR TITLE
Fix a message typo

### DIFF
--- a/src/main/java/com/atomist/rug/cli/command/utils/DependencyResolverExceptionProcessor.java
+++ b/src/main/java/com/atomist/rug/cli/command/utils/DependencyResolverExceptionProcessor.java
@@ -31,7 +31,7 @@ public class DependencyResolverExceptionProcessor {
             }
             else {
                 sb.append(String.format(
-                        "\nUnable to resolve requested archive %s:%s:%s.\nPlease verify that specified archive exists in at least on of your configured repositories.",
+                        "\nUnable to resolve requested archive %s:%s:%s.\nPlease verify that specified archive exists in at least one of your configured repositories.",
                         artifact.group(), artifact.artifact(), artifact.version()));
             }
             return sb.toString();

--- a/src/main/java/com/atomist/rug/cli/resolver/DependencyResolverFactory.java
+++ b/src/main/java/com/atomist/rug/cli/resolver/DependencyResolverFactory.java
@@ -32,9 +32,14 @@ public class DependencyResolverFactory {
             return t;
         });
         MavenProperties properties = MavenPropertiesFactory
-                .create(CommandLineOptions.hasOption("o"), !CommandLineOptions.hasOption("u"));
+                .create(CommandLineOptions.hasOption("offline"), !CommandLineOptions.hasOption("u"));
         MavenBasedDependencyResolver resolver = new MavenBasedDependencyResolver(
                 MavenPropertiesFactory.repositorySystem(), properties, executorService) {
+
+            @Override
+            public String toString() {
+                return super.toString() + "[MavenBasedDependencyResolver with dependency root " + artifact + "]";
+            }
 
             @Override
             protected Dependency createDependencyRoot(ArtifactDescriptor artifact) {
@@ -90,6 +95,11 @@ public class DependencyResolverFactory {
     private DependencyResolver wrapDependencyResolver(DependencyResolver resolver,
             String repoHome) {
         return new CachingDependencyResolver(resolver, repoHome) {
+
+            @Override
+            public String toString() {
+                return super.toString() + "[Caching dependency resolver around " + resolver +"]";
+            }
 
             @Override
             protected boolean isOutdated(ArtifactDescriptor artifact, File file) {


### PR DESCRIPTION
it said: "Please verify that specified archive exists in at least on of your configured repositories."

while I was in there: 
add a few toStrings that were useful in debugging
use a long option name, so I can find it in search