### PR TITLE
Switch to correct licensing (#124)

### DIFF
--- a/src/main/scripts/chocolatey/rug-cli.nuspec
+++ b/src/main/scripts/chocolatey/rug-cli.nuspec
@@ -6,9 +6,9 @@
     <title>Atomist Rug CLI (Install)</title>
     <authors>Atomist, Inc.</authors>
     <owners>Atomist, Inc.</owners>
-    <licenseUrl>https://github.com/atomist/rug-cli/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/atomist/rug-cli/blob/master/src/main/content/LICENSE</licenseUrl>
     <projectUrl>https://www.atomist.com/</projectUrl>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>Atomist Rug CLI to consume, build, execute and test rugs</description>
     <summary>Atomist rug CLI to generate and apply rugs</summary>
     <copyright>2016 Atomist, Inc.</copyright>

--- a/src/main/scripts/deb-package.bash
+++ b/src/main/scripts/deb-package.bash
@@ -185,7 +185,7 @@ function create_package() {
         -m "$Author" \
         --description "Atomist rug CLI" \
         --url https://www.atomist.com \
-        --license "GPL-3.0" \
+        --license "Commercial" \
         --vendor "Atomist, Inc" \
         --deb-suggests "openjdk-8-jdk" \
         --deb-changelog target/linux/deb/changelog \

--- a/src/main/scripts/debian/copyright
+++ b/src/main/scripts/debian/copyright
@@ -1,7 +1,7 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: rug-cli
-Source: https://github.com/atomist/rug-cli/blob/master/LICENSE
+Source: https://github.com/atomist/rug-cli/blob/master/src/main/content/LICENSE
 
 Files: *
 Copyright: 2016 Atomist, Inc.
-License: GPL-3.0
+License: Commercial

--- a/src/main/scripts/rpm-package.bash
+++ b/src/main/scripts/rpm-package.bash
@@ -177,7 +177,7 @@ function create_package() {
         --prefix "/usr/share" \
         --description "Atomist rug CLI" \
         --url https://www.atomist.com \
-        --license "GPLv3" \
+        --license "Commercial" \
         --vendor "Atomist, Inc" \
         -d "java-1.8.0-openjdk-devel" \
         --directories "/usr/share/rug" \


### PR DESCRIPTION
The CLI binary is only distributed under a commercial
license and our previous packages were wrongly reflecting
this was not the case. This fixes it for newer releases.