### PR TITLE
Check child count instead of type

### DIFF
--- a/src/main/java/com/atomist/rug/cli/command/tree/TreeCommand.java
+++ b/src/main/java/com/atomist/rug/cli/command/tree/TreeCommand.java
@@ -17,7 +17,6 @@ import com.atomist.rug.kind.DefaultTypeRegistry$;
 import com.atomist.rug.kind.core.ProjectMutableView;
 import com.atomist.source.ArtifactSource;
 import com.atomist.source.EmptyArtifactSource;
-import com.atomist.tree.TerminalTreeNode;
 import com.atomist.tree.TreeNode;
 import com.atomist.tree.pathexpression.ExpressionEngine;
 import com.atomist.tree.pathexpression.PathExpression;
@@ -97,7 +96,7 @@ public class TreeCommand extends AbstractAnnotationBasedCommand {
                                     .stream().filter(n -> !n.equals("-dynamic"))
                                     .collect(Collectors.toList()), ", ")
                             + "]")
-                    + (!(node instanceof TerminalTreeNode) && id > 0 ? " {" + id + "}" : "")
+                    + ((node.relatedNodes().size() > 0) && id > 0 ? " {" + id + "}" : "")
                     + " " + NodeUtils.value(node);
         }
     }
@@ -115,7 +114,7 @@ public class TreeCommand extends AbstractAnnotationBasedCommand {
                                     .stream().filter(n -> !n.equals("-dynamic"))
                                     .collect(Collectors.toList()), ", ")
                             + "]")
-                    + (!(node instanceof TerminalTreeNode) && id > 0 ? " {" + id + "}" : "");
+                    + ((node.relatedNodes().size() > 0) && id > 0 ? " {" + id + "}" : "");
         }
     }
 }

--- a/src/main/java/com/atomist/rug/cli/tree/TreeNodeTreeCreator.java
+++ b/src/main/java/com/atomist/rug/cli/tree/TreeNodeTreeCreator.java
@@ -2,7 +2,6 @@ package com.atomist.rug.cli.tree;
 
 import com.atomist.graph.GraphNode;
 import com.atomist.rug.cli.tree.Node.Type;
-import com.atomist.tree.TerminalTreeNode;
 import scala.collection.JavaConverters;
 
 import java.util.Collection;
@@ -37,7 +36,7 @@ public abstract class TreeNodeTreeCreator {
 
     private static void collectNodes(GraphNode node, Map<GraphNode, Integer> processed,
             Map<GraphNode, Integer> counts, AtomicInteger counter) {
-        if (!(node instanceof TerminalTreeNode)) {
+        if (node.relatedNodes().size() > 0) {
             if (!processed.containsKey(node)) {
                 int id = counter.incrementAndGet();
                 processed.put(node, id);
@@ -65,7 +64,7 @@ public abstract class TreeNodeTreeCreator {
             Map<GraphNode, Integer> processedNodes, AtomicInteger counter,
             Map<GraphNode, Integer> counts) {
 
-        if (!(node instanceof TerminalTreeNode)) {
+        if (node.relatedNodes().size() > 0) {
             if (!processedNodes.containsKey(node)) {
                 int id = counter.incrementAndGet();
                 processedNodes.put(node, id);


### PR DESCRIPTION
@rod, @cd what do you think of this?

we want to remove TerminalTreeNode.

relatedNodes() is implemented as childNodes() in TreeNode, so this should be the equivalent of isLeaf(), which checks that it has no children.