### PR TITLE
Check if current snapshot is compatible with extension constraints

### DIFF
--- a/src/main/java/com/atomist/rug/cli/command/extension/ExtensionCommand.java
+++ b/src/main/java/com/atomist/rug/cli/command/extension/ExtensionCommand.java
@@ -17,6 +17,7 @@ import com.atomist.rug.resolver.ArtifactDescriptorFactory;
 import com.atomist.rug.resolver.DependencyResolver;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.aether.util.version.GenericVersionScheme;
 import org.eclipse.aether.version.InvalidVersionSpecificationException;
 import org.eclipse.aether.version.Version;
@@ -101,9 +102,10 @@ public class ExtensionCommand extends AbstractAnnotationBasedCommand {
                                 return dependencyResolver.resolveTransitiveDependencies(
                                         ArtifactDescriptorFactory.copyFrom(artifact, newVersion));
                             }
+
                             else {
                                 throw new CommandException(String.format(
-                                        "Extension %s:%s:%s is not compatible.",
+                                        "Extension %s:%s:%s is not compatible with this version of the CLI.",
                                         resolvedArtifact.group(), resolvedArtifact.artifact(),
                                         resolvedArtifact.version()));
                             }
@@ -217,10 +219,21 @@ public class ExtensionCommand extends AbstractAnnotationBasedCommand {
                     return true;
                 }
                 else {
-                    log.info("Extension %s:%s:%s requires %s of %s:%s", extension.group(),
+                    if(cliVersion.toString().endsWith("-SNAPSHOT")){
+                        Version cliSnapshotVersion = scheme.parseVersion(StringUtils.removeEnd(cliVersion.toString(), "-SNAPSHOT"));
+                        if(constraint.containsVersion(cliSnapshotVersion)){
+                            log.warn("Assuming this CLI SNAPSHOT is compatible with the extension...", extension.group(),
+                                    extension.artifact(), extension.version(), constraint.toString(),
+                                    Constants.GROUP, Constants.ARTIFACT, cliVersion);
+                            return true;
+                        }
+                    }
+                    log.warn("Extension %s:%s:%s requires %s of %s:%s, but current version is %s", extension.group(),
                             extension.artifact(), extension.version(), constraint.toString(),
-                            Constants.GROUP, Constants.RUG_ARTIFACT);
+                            Constants.GROUP, Constants.ARTIFACT, cliVersion);
                     return false;
+
+
                 }
             }
             catch (InvalidVersionSpecificationException e) {


### PR DESCRIPTION
If the CLI version is a SNAPSHOT, check if it (minus the -SNAPSHOT) is compatible with the requirements of the extension.

- also fix the error message when they are not compatible