### PR TITLE
Generate Markdown CLI reference documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
--  Support for describing handlers
+-   Support for describing handlers
+-   Generate Markdown documentation for CLI
 
 ### Changed
 
--  Removed executors
--  Upgraded to rug 0.13.+ and rug-resolver
+-   Removed executors
+-   Upgraded to rug 0.13.+ and rug-resolver
 
 ## [0.24.0] - 2017-02-20
 
@@ -38,14 +39,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 -	Added short aliases for commands. Inspect the command help for a list
 	of aliases.
-	
-- 	Ability to run the CLI from a docker image as per 
+
+- 	Ability to run the CLI from a docker image as per
 	https://github.com/atomist/rug-cli/issues/115
 
 ### Changed
 
 - 	Merged PR contributed by @janekdb cleaning up some code as per
-	https://github.com/atomist/rug-cli/pull/107	 	
+	https://github.com/atomist/rug-cli/pull/107
 
 ## [0.23.0] - 2017-02-14
 
@@ -57,7 +58,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  	https://github.com/atomist/rug-cli/issues/96
 
 -   New `shell` command to step into a repl session within the scope of the
-    selected Rug archive. 	
+    selected Rug archive.
 
 ## [0.22.0] - 2017-02-02
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ See the [Rug CLI Quick Start post][quick] and [Rug CLI documentation][doc]
 for more detailed information.
 
 [quick]: https://the-composition.com/rugs-on-the-command-line-eca46492db09#.9ke4rijhd
-[doc]: http://docs.atomist.com/reference/rug-cli/
+[doc]: http://docs.atomist.com/user-guide/interfaces/cli/
 
 ## Installation
 
@@ -38,6 +38,14 @@ You can build, test, and install the project locally with [maven][].
 $ mvn install
 ```
 
+To create the Markdown source for the Rug CLI reference documentation,
+run the `main` method in `CommandUtils` passing is the argument
+`markdown`.
+
+```
+$ java -cp target/rug-cli-*-SNAPSHOT.jar com.atomist.rug.cli.command.CommandUtils markdown
+```
+
 To create a new release of the project, simply push a tag of the form
 `M.N.P` where `M`, `N`, and `P` are integers that form the next
 appropriate [semantic version][semver] for release.  For example:
@@ -52,4 +60,4 @@ release and the comment provided on the annotated tag as the contents
 of the release notes.  It will also automatically upload the needed
 artifacts.
 
-[semver]: http://semver.org 
+[semver]: http://semver.org


### PR DESCRIPTION
Augment CommandUtils to generate Markdown reference documentation for
the CLI.  Documentation is in the README.

Closes #151