### PR TITLE
Generate Markdown CLI reference documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
--  Support for describing handlers
+-   Support for describing handlers
+-   Generate Markdown documentation for CLI
 
 ### Changed
 
--  Removed executors
--  Upgraded to rug 0.13.+ and rug-resolver
+-   Removed executors
+-   Upgraded to rug 0.13.+ and rug-resolver
 
 ## [0.24.0] - 2017-02-20
 
@@ -38,14 +39,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 -	Added short aliases for commands. Inspect the command help for a list
 	of aliases.
-	
-- 	Ability to run the CLI from a docker image as per 
+
+- 	Ability to run the CLI from a docker image as per
 	https://github.com/atomist/rug-cli/issues/115
 
 ### Changed
 
 - 	Merged PR contributed by @janekdb cleaning up some code as per
-	https://github.com/atomist/rug-cli/pull/107	 	
+	https://github.com/atomist/rug-cli/pull/107
 
 ## [0.23.0] - 2017-02-14
 
@@ -57,7 +58,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  	https://github.com/atomist/rug-cli/issues/96
 
 -   New `shell` command to step into a repl session within the scope of the
-    selected Rug archive. 	
+    selected Rug archive.
 
 ## [0.22.0] - 2017-02-02
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ See the [Rug CLI Quick Start post][quick] and [Rug CLI documentation][doc]
 for more detailed information.
 
 [quick]: https://the-composition.com/rugs-on-the-command-line-eca46492db09#.9ke4rijhd
-[doc]: http://docs.atomist.com/reference/rug-cli/
+[doc]: http://docs.atomist.com/user-guide/interfaces/cli/
 
 ## Installation
 
@@ -38,6 +38,13 @@ You can build, test, and install the project locally with [maven][].
 $ mvn install
 ```
 
+To create the Markdown source for the Rug CLI reference documentation,
+run the `main` method in `MkDocs`.
+
+```
+$ java -cp target/rug-cli-*-SNAPSHOT.jar com.atomist.rug.cli.command.MkDocs
+```
+
 To create a new release of the project, simply push a tag of the form
 `M.N.P` where `M`, `N`, and `P` are integers that form the next
 appropriate [semantic version][semver] for release.  For example:
@@ -52,4 +59,4 @@ release and the comment provided on the annotated tag as the contents
 of the release notes.  It will also automatically upload the needed
 artifacts.
 
-[semver]: http://semver.org 
+[semver]: http://semver.org

--- a/src/main/java/com/atomist/rug/cli/command/CommandUtils.java
+++ b/src/main/java/com/atomist/rug/cli/command/CommandUtils.java
@@ -5,19 +5,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.StringTokenizer;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.*;
 
 import com.atomist.rug.cli.Constants;
 import com.atomist.rug.cli.command.utils.ParseExceptionProcessor;

--- a/src/main/java/com/atomist/rug/cli/command/MkDocs.java
+++ b/src/main/java/com/atomist/rug/cli/command/MkDocs.java
@@ -1,0 +1,144 @@
+package com.atomist.rug.cli.command;
+
+import org.apache.commons.cli.Option;
+
+import java.util.*;
+
+public class MkDocs {
+
+    public static void main(String[] args) {
+        markdownPrint();
+    }
+
+    private static void markdownPrint() {
+        ServiceLoadingCommandInfoRegistry commandInfoRegistry = new ServiceLoadingCommandInfoRegistry();
+        System.out.print(markdownDocs(commandInfoRegistry));
+    }
+
+    protected static String markdownDocs(ServiceLoadingCommandInfoRegistry commandInfoRegistry) {
+        StringBuilder markdown =
+                new StringBuilder("Below is the complete list of options and commands for the Rug CLI.\n\n");
+
+        List<CommandInfo> commandInfos = commandInfoRegistry.commands();
+
+        if (commandInfos != null && commandInfos.size() > 0) {
+            CommandInfo someCmdInfo = commandInfos.get(0);
+            Collection<Option> globalOptions = someCmdInfo.globalOptions().getOptions();
+            if (globalOptions != null && globalOptions.size() > 0) {
+                markdown.append("## Global command-line options\n\n");
+                List<Option> globalOptionsArray = new ArrayList<>(globalOptions);
+                Collections.sort(globalOptionsArray, MkDocs::compareOptions);
+                globalOptionsArray.forEach(o -> markdown.append(formatOption(o)));
+            }
+
+            markdown.append("## Commands\n\n");
+            Collections.sort(commandInfos, Comparator.comparing(CommandInfo::name));
+            commandInfos.forEach(c -> markdown.append(formatCommand(c, "###")));
+        }
+
+        return markdown.toString();
+    }
+
+    protected static int compareOptions(Option a, Option b) {
+        String aShort = a.getOpt();
+        String bShort = b.getOpt();
+        String aLong = a.getLongOpt();
+        String bLong = b.getLongOpt();
+        if (aShort != null && aShort.length() > 0 && bShort != null && bShort.length() > 0) {
+            return aShort.compareToIgnoreCase(bShort);
+        } else if (aLong != null && aLong.length() > 0 && bLong != null && bLong.length() > 0) {
+            return aLong.compareToIgnoreCase(bLong);
+        } else if (aShort != null && aShort.length() > 0 && bLong != null && bLong.length() > 0) {
+            return aShort.compareToIgnoreCase(bLong);
+        } else if (aLong != null && aLong.length() > 0 && bShort != null && bShort.length() > 0) {
+            return aLong.compareToIgnoreCase(bShort);
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * This is truly horrible.
+     *
+     * @param c       Command to be formatted.
+     * @param header  Current header level represented as string of hash marks, e.g., "##".
+     * @return        Markdown formatted documentation string.
+     */
+    protected static String formatCommand(CommandInfo c, String header) {
+        StringBuilder cmdMarkdown = new StringBuilder();
+
+        cmdMarkdown.append(header + " `" + c.name() + "`\n\n");
+        cmdMarkdown.append(c.description() + "\n\n");
+
+        String cmdUsage = c.usage();
+        if (cmdUsage != null && cmdUsage.length() > 0) {
+            cmdMarkdown.append("**Usage:**\n\n");
+            cmdMarkdown.append("```console\n$ rug " + cmdUsage + "\n```\n\n");
+        }
+
+        String cmdDetail = c.detail();
+        if (cmdDetail != null && cmdDetail.length() > 0) {
+            cmdMarkdown.append(cmdDetail + "\n\n");
+        }
+
+        List<String> cmdAliases = c.aliases();
+        if (cmdAliases != null && cmdAliases.size() > 0) {
+            cmdMarkdown.append("**Command aliases:** `" + String.join("`, `", cmdAliases) + "`\n\n");
+        }
+
+        List<String> subCmds = c.subCommands();
+        if (subCmds != null && subCmds.size() > 0) {
+            cmdMarkdown.append("**Subcommands:** `" + String.join("`, `", subCmds) + "`\n\n");
+        }
+
+        Collection<Option> cmdOptions = c.options().getOptions();
+        if (cmdOptions != null && cmdOptions.size() > 0) {
+            cmdMarkdown.append("**Command options:**\n\n");
+            List<Option> cmdOptionsArray = new ArrayList<>(cmdOptions);
+            Collections.sort(cmdOptionsArray, MkDocs::compareOptions);
+            cmdOptionsArray.forEach(o -> cmdMarkdown.append(formatOption(o)));
+        }
+
+        return cmdMarkdown.toString();
+    }
+
+    /**
+     * Oh yeah?  It's not as bad as this!
+     *
+     * @param o  Option to be formatted.
+     * @return   Markdown formatted documentation string.
+     */
+    protected static String formatOption(Option o) {
+        String shortString = "";
+        String shortOpt = o.getOpt();
+        if (shortOpt != null && shortOpt.length() > 0) {
+            shortString = "-" + shortOpt;
+        }
+        String longString = "";
+        String longOpt = o.getLongOpt();
+        if (longOpt != null && longOpt.length() > 0) {
+            longString = "--" + longOpt;
+        }
+        String joinString = "";
+        if (shortString.length() > 0 && longString.length() > 0) {
+            joinString = ", ";
+        }
+        String argName = o.getArgName();
+        if (argName != null && argName.length() > 0) {
+            if (shortString.length() > 0) {
+                shortString += " " + argName;
+            }
+            if (longString.length() > 0) {
+                longString += "=" + argName;
+            }
+        }
+        if (shortString.length() > 0) {
+            shortString = "`" + shortString + "`";
+        }
+        if (longString.length() > 0) {
+            longString = "`" + longString + "`";
+        }
+        // This formatting uses the MkDocs def_list markdown extension
+        return String.format("%s%s%s\n:   %s\n\n", shortString, joinString, longString, o.getDescription());
+    }
+}

--- a/src/test/java/com/atomist/rug/cli/command/MkDocsTest.java
+++ b/src/test/java/com/atomist/rug/cli/command/MkDocsTest.java
@@ -1,0 +1,182 @@
+package com.atomist.rug.cli.command;
+
+import com.atomist.rug.cli.command.publish.PublishCommand;
+import com.atomist.rug.cli.command.publish.PublishCommandInfo;
+import com.atomist.rug.resolver.ArtifactDescriptor;
+import com.atomist.rug.resolver.LocalArtifactDescriptor;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.junit.Test;
+
+import static com.atomist.rug.cli.command.MkDocs.*;
+
+public class MkDocsTest {
+
+    @Test
+    public void testSortShortOptions() {
+        Option a = new Option("a", "z a option");
+        Option b = new Option("b", "y b option");
+        assert(compareOptions(a, b) == -1);
+        assert(compareOptions(b, a) == 1);
+        assert(compareOptions(a, a) == 0);
+    }
+
+    @Test
+    public void testSortLongOptions() {
+        Option a = Option.builder().longOpt("a-long-opt").desc("z long a").build();
+        Option b = Option.builder().longOpt("b-long-opt").desc("y long b").build();
+        assert(compareOptions(a, b) == -1);
+        assert(compareOptions(b, a) == 1);
+        assert(compareOptions(a, a) == 0);
+    }
+
+    @Test
+    public void testSortMixedOptions() {
+        Option aShort = new Option("a", "z a option");
+        Option bShort = new Option("b", "y b option");
+        Option aLong = Option.builder().longOpt("a-long-opt").desc("z long a").build();
+        Option bLong = Option.builder().longOpt("b-long-opt").desc("y long b").build();
+        assert(compareOptions(aShort, bLong) == -1);
+        assert(compareOptions(bLong, aShort) == 1);
+        assert(compareOptions(aLong, bShort) == -1);
+        assert(compareOptions(bShort, aLong) == 1);
+    }
+
+    @Test
+    public void testFormatShortOption() {
+        String name = "a";
+        String desc = "the description of short option a";
+        Option o = new Option(name, desc);
+        String optionDoc = formatOption(o);
+        assert(optionDoc.contains("`-" + name + "`\n"));
+        assert(optionDoc.contains(":   " + desc));
+    }
+
+    @Test
+    public void testFormatLongOption() {
+        String name = "a-long-opt";
+        String desc = "the description of long option a-long-opt";
+        Option o = Option.builder().longOpt(name).desc(desc).build();
+        String optionDoc = formatOption(o);
+        assert(optionDoc.contains("`--" + name + "`\n"));
+        assert(optionDoc.contains(":   " + desc));
+    }
+
+    @Test
+    public void testFormatOption() {
+        String shortName = "a";
+        String longName = "a-long-opt";
+        String desc = "the description of long option a-long-opt";
+        Option o = new Option(shortName, longName, false, desc);
+        String optionDoc = formatOption(o);
+        assert(optionDoc.contains("`-" + shortName + "`"));
+        assert(optionDoc.contains("`--" + longName + "`"));
+        assert(optionDoc.contains(":   " + desc));
+    }
+
+    @Test
+    public void testFormatShortOptionArgument() {
+        String name = "a";
+        String desc = "the description of long option a-long-opt";
+        String arg = "ARG";
+        Option o = Option.builder(name).desc(desc).argName(arg).hasArg(true).build();
+        String optionDoc = formatOption(o);
+        assert(optionDoc.contains("`-" + name + " " + arg + "`\n"));
+        assert(optionDoc.contains(":   " + desc));
+    }
+
+    @Test
+    public void testFormatLongOptionArgument() {
+        String name = "a-long-opt";
+        String desc = "the description of long option a-long-opt";
+        String arg = "ARG";
+        Option o = Option.builder().longOpt(name).desc(desc).argName(arg).hasArg(true).build();
+        String optionDoc = formatOption(o);
+        assert(optionDoc.contains("`--" + name + "=" + arg + "`\n"));
+        assert(optionDoc.contains(":   " + desc));
+    }
+
+    @Test
+    public void testFormatCommand() {
+        String cmdName = "test-publish";
+        String cmdDescription = "Create and publish an archive into a remote repository";
+        String cmdDetail = "Create a Rug archive from the current repo and publish it in a remote repository.  "
+                + "Ensure that there is a manifest.yml descriptor in the .atomist directory.  "
+                + "Use -i to specify what repository configuration should be used to publish.  "
+                + "ID should refer to a repository name in cli.yml";
+        String agOpt = "archive-group";
+        String agOptDesc = "Override archive group with AG";
+        String avOpt = "archive-version";
+        String avOptDesc = "Override archive version with AV";
+
+        class TestCommandInfo extends AbstractLocalArtifactDescriptorProvider
+                implements CommandInfo {
+
+            public TestCommandInfo() {
+                super(PublishCommand.class, cmdName);
+            }
+
+            @Override
+            public String description() {
+                return cmdDescription;
+            }
+
+            @Override
+            public String detail() {
+                return cmdDetail;
+            }
+
+            @Override
+            public Options options() {
+                Options options = new Options();
+                options.addOption(Option.builder().longOpt(agOpt).argName("AG").hasArg(true)
+                        .required(false).desc(agOptDesc).build());
+                options.addOption(Option.builder("a").longOpt(avOpt).argName("AV").hasArg(true)
+                        .required(false).desc(avOptDesc).build());
+                options.addOption(Option.builder("i").longOpt("id").argName("ID").hasArg(true)
+                        .required(false).desc("ID identifying the repository to publish into").build());
+
+                return options;
+            }
+
+            @Override
+            public int order() {
+                return 70;
+            }
+
+            @Override
+            public String usage() {
+                return "publish [OPTION]...";
+            }
+
+            @Override
+            public String group() {
+                return "2";
+            }
+
+            @Override
+            public boolean enabled(ArtifactDescriptor artifact) {
+                return artifact instanceof LocalArtifactDescriptor
+                        || artifact.extension().equals(ArtifactDescriptor.Extension.ZIP);
+            }
+        }
+
+        CommandInfo cmdInfo = new TestCommandInfo();
+        String doc = formatCommand(cmdInfo, "##");
+        assert(doc.contains("# `" + cmdName + "`"));
+        assert(doc.contains(cmdDescription));
+        assert(doc.contains(cmdDetail));
+        assert(doc.contains("`--" + agOpt + "=AG`"));
+        assert(doc.contains(agOptDesc));
+        assert(doc.contains("`--" + avOpt + "=AV`"));
+        assert(doc.contains(avOptDesc));
+    }
+
+    @Test
+    public void testMarkdownDocs() {
+        ServiceLoadingCommandInfoRegistry commandInfoRegistry = new ServiceLoadingCommandInfoRegistry();
+        String docs = markdownDocs(commandInfoRegistry);
+        assert(docs.contains("# Global command-line options\n"));
+        assert(docs.contains("# Commands\n"));
+    }
+}


### PR DESCRIPTION
Add MkDocs class and tests to generate Markdown reference
documentation for the CLI.  Documentation is in the README.

Closes #151